### PR TITLE
remove nullable annotation

### DIFF
--- a/library/src/main/java/net/newstyleservice/common_ktx/extension/Date_Extension.kt
+++ b/library/src/main/java/net/newstyleservice/common_ktx/extension/Date_Extension.kt
@@ -1,13 +1,11 @@
 package net.newstyleservice.common_ktx.extension
 
-import androidx.annotation.Nullable
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
 
-@Nullable
 fun Date.toString(
     pattern: String = "yyyy/MM/dd HH:mm:ss",
     locale: Locale = Locale.getDefault()


### PR DESCRIPTION
こんにちは、Qiitaを見てきました。
自分の学びのためソースコードを拝見させていただきました。

気になる箇所があったのでPRします。

拡張関数Date.toStringに@Nullableアノテーションが付与されていますが、
@NullableアノテーションはNonNull型、Nullable型を表現できないJavaのために用意されているので、
戻り値としてString?が指定されているのでNullableであることが明らかです。

https://developer.android.com/studio/write/annotations?hl=ja